### PR TITLE
ci: scope GitHub Actions permissions to jobs (Aikido)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,14 @@ on:
   release:
     types: [created]
 
-permissions:
-  contents: write
-  packages: write
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
 
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2
         with:
-          version: latest
+          version: 10
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
## Summary
- Move workflow-level `permissions: { contents: write, packages: write }` into the `build` job; set the workflow level to `permissions: {}` so future jobs must opt in explicitly. Resolves Aikido `AIK_yaml_gh-actions-overly-broad-permissions` (CWE-250).
- Pin `pnpm-action-setup` to `version: 10`. `latest` now resolves to pnpm v11, which drops the legacy `package.json` `pnpm.*` config keys and bumps the minimum Node requirement; `pnpm install` has been failing on every CI run since v11 shipped. Pinning to v10 restores the previous working state without changing the project layout or Node matrix.

## Aikido Issues Resolved
- [#211116553](https://app.aikido.dev/issues/26050172/detail?singleIssueFilter=211116553&status=open&team_id_filter=296964) — `contents: write` at workflow level
- [#211116554](https://app.aikido.dev/issues/26050172/detail?singleIssueFilter=211116554&status=open&team_id_filter=296964) — `packages: write` at workflow level

## Why this PR is split from a previous attempt
Earlier PR #11 also bumped the Node matrix to 22.x and added `pnpm.onlyBuiltDependencies` to `package.json` to work around two unrelated pnpm v11 breakages. Those changes are out of scope for an Aikido permissions fix and should be decided separately — this PR keeps the diff to the minimum needed to land the security fix.

## Verification
- Workflow YAML is syntactically valid; permissions semantics preserved (build job retains both original permissions)
- CI uses pnpm v10 → matches the last known-green build (2026-02-28)