### PR TITLE
ci: drop persisted Git credentials in actions/checkout (Aikido)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-allowBuilds:
-  esbuild: set this to true or false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: set this to true or false


### PR DESCRIPTION
## Summary

Aikido flags `actions/checkout` for leaving the job token in `.git/config` (`http.extraheader`) after checkout, where any later step — including third-party actions — can read it.

Added `persist-credentials: false` to `.github/workflows/build.yml`.

build.yml runs pnpm install/build, uploads artifacts, and creates releases via softprops/action-gh-release (which authenticates with its own token input). Nothing uses the ambient git credential. So this is a no-op for CI behaviour.

## Aikido Issue Resolved

- [383787701](https://app.aikido.dev/issues/33607621/detail?singleIssueFilter=383787701&status=open) — GitHub Action actions/checkout persist Git credentials in workflow

Part of Aikido group [33607621](https://app.aikido.dev/issues/33607621/detail?status=open), which spans 10 workflows across 6 qor5 repos.

## Verification

- Workflow file parses as valid YAML
- No source changes — CI on this PR exercises the modified workflow directly